### PR TITLE
feat(studio): add toggle for powered by freetree watermark

### DIFF
--- a/web/src/components/freetree-preview.tsx
+++ b/web/src/components/freetree-preview.tsx
@@ -11,6 +11,7 @@ export interface FreetreeLink {
 export interface FreetreeProfile {
     displayName: string;
     bio?: string;
+    showWatermark?: boolean;
     links: FreetreeLink[];
 }
 
@@ -106,9 +107,21 @@ export function FreetreePreview({ profile }: FreetreePreviewProps) {
                     </div>
 
                     {/* Footer */}
-                    <div className="text-center mt-8 pb-6 animate-in fade-in duration-700 delay-500">
-                        <p className="text-xs text-muted-foreground/60">Powered by freetree</p>
-                    </div>
+                    {profile.showWatermark !== false && (
+                        <div className="text-center mt-8 pb-6 animate-in fade-in duration-700 delay-500">
+                            <p className="text-xs text-muted-foreground/60">
+                                Powered by{' '}
+                                <a
+                                    href="https://github.com/0x4bs3nt/freetree"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="underline hover:text-primary transition-colors"
+                                >
+                                    freetree
+                                </a>
+                            </p>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Switch as SwitchPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Switch({
+    className,
+    size = 'default',
+    ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+    size?: 'sm' | 'default';
+}) {
+    return (
+        <SwitchPrimitive.Root
+            data-slot="switch"
+            data-size={size}
+            className={cn(
+                'data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50',
+                className
+            )}
+            {...props}
+        >
+            <SwitchPrimitive.Thumb
+                data-slot="switch-thumb"
+                className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+            />
+        </SwitchPrimitive.Root>
+    );
+}
+
+export { Switch };

--- a/web/src/pages/dashboard/home.tsx
+++ b/web/src/pages/dashboard/home.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { FreetreePreview, type FreetreeLink, type FreetreeProfile } from '@/components/freetree-preview';
@@ -24,6 +25,7 @@ export default function DashboardHome() {
     const [profile, setProfile] = useState<FreetreeProfile>({
         displayName: '',
         bio: '',
+        showWatermark: true,
         links: [],
     });
 
@@ -120,6 +122,33 @@ export default function DashboardHome() {
                                         {profile.bio?.length || 0}/200
                                     </span>
                                 </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Branding Section */}
+                    <Card className="border-border bg-card shadow-sm hover:shadow-md transition-shadow">
+                        <CardHeader className="pb-2">
+                            <CardTitle>Branding</CardTitle>
+                            <CardDescription>Control how freetree branding appears on your page</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="flex items-center justify-between rounded-lg border border-border p-4">
+                                <div className="space-y-0.5">
+                                    <Label htmlFor="watermark" className="font-medium text-foreground">
+                                        Show "Powered by freetree"
+                                    </Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        Display a small credit link to support the project
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="watermark"
+                                    checked={profile.showWatermark}
+                                    onCheckedChange={(checked) =>
+                                        setProfile((prev) => ({ ...prev, showWatermark: checked }))
+                                    }
+                                />
                             </div>
                         </CardContent>
                     </Card>


### PR DESCRIPTION
## Summary
Implemented #14 - Added a toggle option to show/hide the "Powered by freetree" watermark on user pages, allowing users to opt in/out of displaying the credit.

## Features Added
- Toggle switch to show/hide "Powered by freetree" text (enabled by default)
- "Branding" section in Studio dashboard with clear description
- "freetree" text now links to the GitHub repository
- Watermark visibility updates in real-time in the preview
- Added Shadcn Switch component

## Files Changed
- web/src/components/freetree-preview.tsx - Added `showWatermark` to profile interface, conditional footer rendering with GitHub link
- web/src/pages/dashboard/home.tsx - Added "Branding" section with toggle switch
- web/src/components/ui/switch.tsx - New Shadcn Switch component

## Task List
- [x] Toggle option in dashboard
- [x] Conditional watermark display in preview
- [x] Link "freetree" text to GitHub repo

<img width="2442" height="954" alt="image" src="https://github.com/user-attachments/assets/421824ae-1971-490b-b00d-da4d489a9951" />
<img width="2143" height="907" alt="image" src="https://github.com/user-attachments/assets/6a7d4cef-3ff5-4f39-820d-78748540d59e" />
