### PR TITLE
refactor(ui): remove 'use client' directives

### DIFF
--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
 

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { Combobox as ComboboxPrimitive } from '@base-ui/react';
 

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 

--- a/web/src/components/ui/input-group.tsx
+++ b/web/src/components/ui/input-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { Label as LabelPrimitive } from 'radix-ui';
 

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { Select as SelectPrimitive } from 'radix-ui';
 

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { type VariantProps } from 'class-variance-authority';
 import { ToggleGroup as ToggleGroupPrimitive } from 'radix-ui';

--- a/web/src/components/ui/toggle.tsx
+++ b/web/src/components/ui/toggle.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Toggle as TogglePrimitive } from 'radix-ui';


### PR DESCRIPTION
Fix #9
We all know that *nobody* will do it, so I will

# Summary

Remove all mentions of 'use client' in ShadCN components