### PR TITLE
feat: add community templates (bug report, feature request, PR template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- **Browser**: [e.g. Chrome, Firefox, Safari]
+- **OS**: [e.g. Windows, macOS, Linux]
+- **Version/Commit**: [e.g. main branch, specific commit hash]
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- A brief description of the changes in this PR -->
+
+## Related Issue
+<!-- Link to the issue this PR addresses, e.g. Closes #123 -->
+
+## Changes Made
+<!-- List the specific changes made in this PR -->
+- 
+
+## Screenshots
+<!-- If applicable, add screenshots to demonstrate UI changes -->
+
+## Checklist
+- [ ] Code follows the project's style guidelines
+- [ ] Ran `bun check` (frontend) / `pre-commit` (backend) with no errors
+- [ ] Self-reviewed the code for any obvious issues
+- [ ] Tested changes locally
+- [ ] Updated documentation if needed
+
+## Additional Notes
+<!-- Any additional context or notes for reviewers -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Changes Made
 <!-- List the specific changes made in this PR -->
-- 
+-
 
 ## Screenshots
 <!-- If applicable, add screenshots to demonstrate UI changes -->


### PR DESCRIPTION
## Summary
Added community health files to improve project standards and help organize contributions. implements #33 

## Changes Made
- Added bug report issue template .github/ISSUE_TEMPLATE/bug_report.md
- Added feature request issue template .github/ISSUE_TEMPLATE/feature_request.md
- Added pull request template .github/pull_request_template.md]

## Benefits
- Standardizes issue and PR submissions
- Guides contributors on what information to include
- Completes the GitHub Community Standards checklist
- Makes the project look more professional and maintained