### PR TITLE
feat(settings): add account settings UI components

### DIFF
--- a/web/src/components/settings/action-row.tsx
+++ b/web/src/components/settings/action-row.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@/components/ui/button';
+
+export function ActionRow({
+    title,
+    description,
+    action,
+    destructive,
+}: {
+    title: string;
+    description?: string;
+    action: string;
+    destructive?: boolean;
+}) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <div>
+                <p className="text-lg">{title}</p>
+                {description && <p className="text-sm text-muted-foreground">{description}</p>}
+            </div>
+
+            <Button
+                variant={destructive ? 'default' : 'outline'}
+                className={
+                    destructive
+                        ? 'rounded-full bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600 px-4 py-4'
+                        : 'px-4 py-4 rounded-3xl bg-muted'
+                }
+            >
+                {action}
+            </Button>
+        </div>
+    );
+}

--- a/web/src/components/settings/pages-list.tsx
+++ b/web/src/components/settings/pages-list.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui/button';
+
+export function PagesList({ pages }: { pages: { id: string; username: string }[] }) {
+    return (
+        <div className="space-y-4">
+            {pages.map((page) => (
+                <div key={page.id} className="flex items-center justify-between py-2">
+                    <div className="flex items-center gap-3">
+                        <div className="h-12 w-12 rounded-full bg-muted" />
+                        <span className="text-xl font-semibold">@{page.username}</span>
+                    </div>
+
+                    <div className="flex gap-2">
+                        <Button variant="outline" size="lg" className="rounded-3xl px-4 py-4 bg-muted">
+                            Edit
+                        </Button>
+                        <Button variant="destructive" size="lg" className="rounded-3xl px-4 py-4">
+                            Delete
+                        </Button>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/web/src/components/settings/setting-row.tsx
+++ b/web/src/components/settings/setting-row.tsx
@@ -1,0 +1,19 @@
+export function SettingsRow({
+    title,
+    description,
+    right,
+}: {
+    title: string;
+    description?: string;
+    right: React.ReactNode;
+}) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <div>
+                <p className="text-lg">{title}</p>
+                {description && <p className="text-sm text-muted-foreground">{description}</p>}
+            </div>
+            {right}
+        </div>
+    );
+}

--- a/web/src/components/settings/setting-section.tsx
+++ b/web/src/components/settings/setting-section.tsx
@@ -1,0 +1,8 @@
+export function SettingsSection({ title, children }: { title: string; children: React.ReactNode }) {
+    return (
+        <section className="space-y-2">
+            <h2 className="text-2xl font-semibold pt-2 pb-2">{title}</h2>
+            {children}
+        </section>
+    );
+}

--- a/web/src/pages/settings/account-settings.tsx
+++ b/web/src/pages/settings/account-settings.tsx
@@ -1,0 +1,117 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+
+import { SettingsSection } from '@/components/settings/setting-section';
+import { SettingsRow } from '@/components/settings/setting-row';
+import { ActionRow } from '@/components/settings/action-row';
+import { PagesList } from '@/components/settings/pages-list';
+
+const pages = [
+    { id: '1', username: 'agustin' },
+    { id: '2', username: 'aguscruiz' },
+    { id: '3', username: 'memes' },
+];
+
+export default function AccountSettingsPage() {
+    return (
+        <div className="min-h-screen w-full">
+            <header className="max-w-3xl mx-auto flex px-4 py-6 pt-12">
+                <img src="/urlinks.svg" alt="Urlinks" className="h-8 w-auto" />
+            </header>
+
+            <main className="mx-auto max-w-3xl px-4 space-y-10">
+                <SettingsSection title="Your pages">
+                    <Card className="border border-border shadow-sm">
+                        <div className="px-6 pb-4">
+                            <h3 className="text-xl font-semibold">Create or customize your pages</h3>
+                            <p className="text-sm text-muted-foreground">
+                                You can create up to 5 pages in your account
+                            </p>
+                        </div>
+
+                        <CardContent className="pt-0">
+                            <PagesList pages={pages} />
+                        </CardContent>
+
+                        <div className="border-t border-border" />
+
+                        <CardContent>
+                            <Button className="rounded-full text-md bg-black text-white px-4 py-2 hover:bg-black/90">
+                                <Plus className="mr-1 h-4 w-4" />
+                                New page
+                            </Button>
+                        </CardContent>
+                    </Card>
+                </SettingsSection>
+
+                <SettingsSection title="Notification preferences">
+                    <Card className="border border-border shadow-sm">
+                        <CardContent className="space-y-4">
+                            {[1, 2, 3].map((i) => (
+                                <SettingsRow
+                                    key={i}
+                                    title="Placeholder"
+                                    description="placeholder text"
+                                    right={
+                                        <Switch
+                                            className="
+                                               data-[state=checked]:bg-black
+                                               [&>span]:bg-muted"
+                                        />
+                                    }
+                                />
+                            ))}
+                        </CardContent>
+                    </Card>
+                </SettingsSection>
+
+                <SettingsSection title="Your account">
+                    <Card className="border border-border shadow-sm">
+                        <CardContent className="space-y-6">
+                            <SettingsRow
+                                title='Show "powered by urlinks" in your page footer'
+                                description="You can support urlinks by leaving it on, it helps people find out about this app and it means a lot us."
+                                right={
+                                    <Switch
+                                        className="
+                                               data-[state=checked]:bg-black
+                                               [&>span]:bg-muted"
+                                    />
+                                }
+                            />
+
+                            <ActionRow
+                                title="Change email"
+                                description="Change your current email used for login"
+                                action="Change email"
+                            />
+
+                            <ActionRow
+                                title="Change password"
+                                description="Change your current password"
+                                action="Change password"
+                            />
+
+                            <ActionRow
+                                title="Log out"
+                                description="Close your session and log out of urlinks"
+                                action="Logout"
+                            />
+
+                            <ActionRow
+                                title="Delete account"
+                                description="Permanently delete your account and information"
+                                action="Delete account"
+                                destructive
+                            />
+                        </CardContent>
+                    </Card>
+                </SettingsSection>
+
+                <footer className="py-5 text-center text-sm text-muted-foreground">2026 urlinks etc.</footer>
+            </main>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
Adds a reusable account settings UI based on the Figma.

## Changes Made
<!-- List the specific changes made in this PR -->
- Introduces reusable settings components (section, rows, actions)
- Implements account settings page UI (frontend only)


## Screenshots
<!-- If applicable, add screenshots to demonstrate UI changes -->
<img width="1767" height="955" alt="Screenshot from 2026-01-22 23-20-09" src="https://github.com/user-attachments/assets/58d8e178-5591-4bf1-a91d-2ae4b2928fb5" />
<img width="1753" height="891" alt="Screenshot from 2026-01-22 23-24-34" src="https://github.com/user-attachments/assets/76ab2c2d-e0e0-405b-89dc-272b5d6dcd16" />



## Checklist
- [x] Code follows the project's style guidelines
- [x] Ran `bun check` (frontend) / `pre-commit` (backend) with no errors
- [x] Self-reviewed the code for any obvious issues
- [x] Tested changes locally
- [x] Updated documentation if needed

## Additional Notes
- No global styles or tokens were changed.
- Minor scoped styling overrides were used to better align with the current Figma.