### PR TITLE
feat: use local filesystem storage in development

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,7 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
 # Object Storage settings (Cloudflare R2)
+# NOTE: These are only required when DEBUG=False (production)
 R2_ENDPOINT_URL=[string]
 R2_ACCESS_KEY=[string]
 R2_SECRET_KEY=[string]

--- a/backend/apps/profile_app/models/link.py
+++ b/backend/apps/profile_app/models/link.py
@@ -39,3 +39,8 @@ class Link(models.Model):
 
     def __str__(self):
         return f"{self.title} ({self.page.display_name})"
+
+    def delete(self, *args, **kwargs):
+        if self.icon:
+            self.icon.delete(save=False)
+        return super().delete(*args, **kwargs)

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -82,20 +82,6 @@ DATABASES = {
     }
 }
 
-STORAGES = {
-    "default": {
-        "BACKEND": "storages.backends.s3.S3Storage",
-        "OPTIONS": {
-            "endpoint_url": os.getenv("R2_ENDPOINT_URL"),
-            "access_key": os.getenv("R2_ACCESS_KEY"),
-            "secret_key": os.getenv("R2_SECRET_KEY"),
-            "bucket_name": os.getenv("R2_BUCKET_NAME"),
-            "signature_version": "s3v4",
-        },
-    },
-    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
-}
-
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
@@ -170,5 +156,36 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+
+# File Storage Configuration
+if DEBUG:
+    # Local development: use filesystem storage
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
+    # Ensure media directory exists in development
+    os.makedirs(MEDIA_ROOT, exist_ok=True)
+else:
+    # Production: use Cloudflare R2 (S3-compatible)
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.s3.S3Storage",
+            "OPTIONS": {
+                "endpoint_url": os.getenv("R2_ENDPOINT_URL"),
+                "access_key": os.getenv("R2_ACCESS_KEY"),
+                "secret_key": os.getenv("R2_SECRET_KEY"),
+                "bucket_name": os.getenv("R2_BUCKET_NAME"),
+                "signature_version": "s3v4",
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
## Summary

- Use `FileSystemStorage` when `DEBUG=True` to save uploaded files locally in the `media/` folder
- Production (`DEBUG=False`) continues using Cloudflare R2
- Add `delete()` method to `Link` model to clean up icon files on deletion
- Document R2 credentials as optional in development

## Changes

- **backend/project/settings.py**: Conditional storage configuration based on DEBUG mode
- **backend/.env.example**: Added note that R2 credentials are only required in production
- **backend/apps/profile_app/models/link.py**: Added delete() method for file cleanup

## Benefits

- No R2 charges during local development
- Simpler setup for new developers (no R2 credentials needed)
- Faster development (local filesystem vs network requests)

Closes #51